### PR TITLE
fix: convert tracer from CJS to ESM

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -1,13 +1,14 @@
-const tracer = require('./tracer')
+import tracer from './tracer';
 import { NestFactory } from '@nestjs/core';
 import { AppModule } from './app.module';
-  // All of your application code and any imports that should leverage
-  // OpenTelemetry automatic instrumentation must go here.
+
+// All of your application code and any imports that should leverage
+// OpenTelemetry automatic instrumentation must go here.
 
 async function bootstrap() {
-    await tracer.start();
-    const app = await NestFactory.create(AppModule);
-    await app.listen(3001);
-  }
-  bootstrap();
+  await tracer.start();
 
+  const app = await NestFactory.create(AppModule);
+  await app.listen(3001);
+}
+bootstrap();

--- a/src/tracer.ts
+++ b/src/tracer.ts
@@ -1,41 +1,42 @@
-// tracing.js
+'use strict';
 
-'use strict'
+import * as grpc from '@grpc/grpc-js';
+import { getNodeAutoInstrumentations } from '@opentelemetry/auto-instrumentations-node';
+import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-grpc';
+import { Resource } from '@opentelemetry/resources';
+import * as opentelemetry from '@opentelemetry/sdk-node';
+import { SemanticResourceAttributes } from '@opentelemetry/semantic-conventions';
 
-const opentelemetry = require('@opentelemetry/sdk-node');
-const { getNodeAutoInstrumentations } = require('@opentelemetry/auto-instrumentations-node');
-const { OTLPTraceExporter } = require('@opentelemetry/exporter-trace-otlp-grpc');
-const { Resource } = require('@opentelemetry/resources');
-const { SemanticResourceAttributes } = require('@opentelemetry/semantic-conventions');
-const grpc = require('@grpc/grpc-js');
-
-// configure the SDK to export telemetry data to the console
-// enable all auto-instrumentations from the meta package
+// Configure the SDK to export telemetry data to the console
+// Enable all auto-instrumentations from the meta package
 const exporterOptions = {
   url: 'http://localhost:4317',
   credentials: grpc.credentials.createInsecure(),
-}
+};
+
 const traceExporter = new OTLPTraceExporter(exporterOptions);
 const sdk = new opentelemetry.NodeSDK({
   traceExporter,
   instrumentations: [getNodeAutoInstrumentations()],
   resource: new Resource({
-    [SemanticResourceAttributes.SERVICE_NAME]: 'sampleNestJsApp'
+    [SemanticResourceAttributes.SERVICE_NAME]: 'sampleNestJsApp',
   }),
 });
 
 // initialize the SDK and register with the OpenTelemetry API
 // this enables the API to record telemetry
-sdk.start()
+sdk
+  .start()
   .then(() => console.log('Tracing initialized'))
   .catch((error) => console.log('Error initializing tracing', error));
 
 // gracefully shut down the SDK on process exit
 process.on('SIGTERM', () => {
-  sdk.shutdown()
+  sdk
+    .shutdown()
     .then(() => console.log('Tracing terminated'))
     .catch((error) => console.log('Error terminating tracing', error))
     .finally(() => process.exit(0));
 });
 
-module.exports = sdk
+export default sdk;


### PR DESCRIPTION
Fixed the `tracer.ts` file to follow ES conventions that NestJS does by design.